### PR TITLE
Fix safe shell exit when environment variable undefined in kube-functions

### DIFF
--- a/images/epics-dev/home/bin/kube-functions.sh
+++ b/images/epics-dev/home/bin/kube-functions.sh
@@ -11,7 +11,7 @@ fi
 if [[ -z "$K8S_HELM_REGISTRY" ]] ; then
     echo please set the environment variables K8S_IMAGE_REGISTRY
     echo to point to the URL of the HELM registry in which IOC charts are held
-    exit 1
+    return 1
 fi
 
 export HELM_EXPERIMENTAL_OCI=1


### PR DESCRIPTION
When running `source kube-functions.sh` without having set `$K8S_HELM_REGISTRY` my shell immediately closes. The script is supposed to print an error and exit gracefully in this case, it doesn't because it runs `exit 1` rather than `return 1`. The latter stops sourcing without closing the running shell. 