### PR TITLE
additional development packages (dls dev-centos image)

### DIFF
--- a/dls/dev-centos/Dockerfile
+++ b/dls/dev-centos/Dockerfile
@@ -10,7 +10,7 @@ FROM centos:7
 # dev tools and libraries
 RUN yum update -y && \
     yum groupinstall -y "Development Tools" && \
-    yum install -y redhat-lsb-core libusbx net-snmp-libs environment-modules git2u net-tools screen cmake lapack-devel readline-devel pcre-devel boost-devel libpcap-devel numactl-libs
+    yum install -y glibc.i686 redhat-lsb-core libusbx net-snmp-libs environment-modules git2u net-tools screen cmake lapack-devel readline-devel pcre-devel boost-devel libpcap-devel numactl-libs
 
 # edm dependencies
 RUN yum install -y epel-release && \

--- a/dls/dev-centos/Dockerfile
+++ b/dls/dev-centos/Dockerfile
@@ -10,11 +10,17 @@ FROM centos:7
 # dev tools and libraries
 RUN yum update -y && \
     yum groupinstall -y "Development Tools" && \
-    yum install -y redhat-lsb-core libusbx net-snmp-libs environment-modules git2u net-tools screen lapack-devel
+    yum install -y redhat-lsb-core libusbx net-snmp-libs environment-modules git2u net-tools screen cmake lapack-devel readline-devel pcre-devel boost-devel libpcap-devel numactl-libs
 
 # edm dependencies
 RUN yum install -y epel-release && \
-    yum install -y giflib-devel libXmu-devel libpng-devel libXtst-devel zlib-devel xorg-x11-proto-devel motif-devel libX11-devel libXp-devel libXpm-devel
+    yum install -y giflib-devel libXmu-devel libpng-devel libXtst-devel zlib-devel xorg-x11-proto-devel motif-devel libX11-devel libXp-devel libXpm-devel libtirpc-devel
+
+# areaDetector dependencies
+RUN yum install -y libxml2-devel libjpeg-turbo-devel libtiff-devel
+
+# Odin dependencies
+RUN yum install -y zeromq-devel librdkafka-devel
 
 # QT4 dependencies
 ENV QT_X11_NO_MITSHM=1

--- a/dls/dev-centos/run-dev.sh
+++ b/dls/dev-centos/run-dev.sh
@@ -7,6 +7,7 @@ environ="-e DISPLAY -e HOME"
 volumes="-v /dls_sw/prod:/dls_sw/prod \
         -v /dls_sw/work:/dls_sw/work \
         -v /dls_sw/epics:/dls_sw/epics \
+        -v /dls_sw/targetOS/vxWorks/Tornado-2.2:/dls_sw/targetOS/vxWorks/Tornado-2.2 \
         -v /dls_sw/apps:/dls_sw/apps \
         -v /dls_sw/etc:/dls_sw/etc \
         -v /scratch:/scratch \


### PR DESCRIPTION
We need a few more development packages installed into this image to support what we currently have on DLS RHEL7 workstations:

* cmake (weirdly that doesn't seem to be included in Development Tools)
* Boost
* ZeroMQ
* Kafka
* NUMA control lib
* PCAP library
* PCRE
* bunch of -devel libs required to build EPICS base and/or areaDetector...

I found the above packages by scanning through a lot of our binaries and looking for missing dependencies with `ldd`. Also based on previous work I did a while ago (albeit for CentOS8), summarised here: https://epics.anl.gov/tech-talk/2020/msg00735.php