### PR TITLE
Make all locales available

### DIFF
--- a/dls-images/dev-c7/Dockerfile
+++ b/dls-images/dev-c7/Dockerfile
@@ -53,3 +53,7 @@ RUN yum install -y xfreerdp zenity
 
 # useful tools 
 RUN yum install -y meld
+
+# Workaround to ensure all locales are available
+RUN sed -i "/override_install_langs=en_US/d" /etc/yum.conf
+RUN yum reinstall -y glibc-common


### PR DESCRIPTION
#4 is caused by only a subset of locales being installed
due to `override_install_lang` being set in `/etc/yum.conf`.

This commit removes this line from yum.conf and reinstalls
glibc-common which has the effect of making all locales available.

This is one possible fix for this issue.

(I added a newline at the end of the file also)

Fixes #4